### PR TITLE
Update install_requires for BeautifulSoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     license='MIT',
     packages = ['pybindxml'],
     url = 'http:://github.com/jforman/pybindxml',
-    install_requires = ['bs4.BeautifulSoup'],
+    install_requires = ['BeautifulSoup4'],
 )


### PR DESCRIPTION
pybindxml fails to install in python 2.6 on a Red Hat Enterprise Linux 6 machine when it has 'install_requires bs4.BeautilfulSoup'.  