### PR TITLE
Fix for non-integer serials

### DIFF
--- a/pybindxml/reader.py
+++ b/pybindxml/reader.py
@@ -139,7 +139,7 @@ class XmlV22(XmlAbstract):
                 zone_class = zone.find('rdataclass').string
                 if zone_class != 'IN':
                     continue
-                serial = int(zone.find('serial').string)
+                serial = zone.find('serial').string
                 zone_dict[zone_name] = {}
                 zone_dict[zone_name][view_name] = {}
                 zone_dict[zone_name][view_name].update({
@@ -195,7 +195,7 @@ class XmlV30(XmlAbstract):
                 zone_dict[zone['name']] = {}
                 zone_dict[zone['name']][view['name']] = {}
                 zone_dict[zone['name']][view['name']].update({
-                        'serial': int(zone.find('serial').string)
+                        'serial': zone.find('serial').string
                         })
                 for counter_type in zone.find_all('counters'):
                     # rcode, qtype, etc.


### PR DESCRIPTION
When BIND has a problem loading a zone (e.g. due to an unreadable journal file) the statistics page contains `-` for this zone as serial instead of an integer. Up to now `pybindxml` fails with a ValueError in such case as it assumes that the serial is an integer. This commit fixes that behavior by simply removing the assumption that the serial has to be an integer.
